### PR TITLE
chore: modify lint-staged setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,12 +53,10 @@
   "packageManager": "pnpm@6.30.1",
   "lint-staged": {
     "**/*.{ts}": [
-      "eslint --fix",
-      "git add"
+      "eslint --fix"
     ],
     "**/*.{js,ts,md,json,yml}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   }
 }


### PR DESCRIPTION
`git add` is needless since v10
https://github.com/okonet/lint-staged#v10